### PR TITLE
Add todo check for github action build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,7 @@ jobs:
 
     - name: Tests results
       run: make test
+
+    - name: Validate TODOs
+      if: github.base_ref == 'master'
+      run: (! grep -rin "//todo" ./cmd ./docs ./internal ./spec)


### PR DESCRIPTION
Fails the build if a source file contains a `todo` comment (`//todo` case insensitive) if the PR is sent to the master branch