### PR TITLE
Support downloading artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,15 @@ jobs:
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
-
-    - name: Build
-      run: make build-cli
+     
+    - name: Build Artifacts
+      run: make build-cli-all
 
     - name: Tests results
       run: make test
+    
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+          name: Build artifacts
+          path: builder/target


### PR DESCRIPTION
## Describe your problem(s)
It wasn't possible to download build artifacts in github actions.

## Describe your solution
By adding the upload artifact github actions the build artifacts can be downloaded now
![image](https://user-images.githubusercontent.com/8238078/67864850-542f8f00-fb4c-11e9-90a8-7cf18e55b022.png)


## Checklist

~- [ ] Unit tests~ N/A as this is for the build
~- [ ] Documentation~ N/A as this is for the build
~- [ ] Updated release note~ N/A as this is for the build
