### PR TITLE
Add capability to disable SSL cerification in login

### DIFF
--- a/internal/pkg/cmd/auth/login/login.go
+++ b/internal/pkg/cmd/auth/login/login.go
@@ -158,22 +158,22 @@ func (c *oauthClient) exchange(code string) (*oauth2.Token, error) {
 	return c.oauthConf.Exchange(c.ctx, code)
 }
 
-func createOathClient(clientId, redirectUrl, authUrl, tokenUrl string, insecure bool) *oauthClient {
+func createOathClient(clientId, redirectUrl, authUrl, tokenUrl string, skipSslVerify bool) *oauthClient {
 	oauthConf := &oauth2.Config{
 		ClientID:     clientId,
 		Endpoint:     oauth2.Endpoint{
 			AuthURL:   authUrl,
 			TokenURL:  tokenUrl,
-			AuthStyle: 1,
+			AuthStyle: oauth2.AuthStyleInParams,
 		},
 		RedirectURL:  redirectUrl,
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipSslVerify},
 	}
 	httpClient := &http.Client{Transport: tr}
-	ctx := context.WithValue(context.TODO(), oauth2.HTTPClient, httpClient)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
 
 	return &oauthClient{
 		oauthConf: oauthConf,

--- a/internal/pkg/cmd/auth/login/login_test.go
+++ b/internal/pkg/cmd/auth/login/login_test.go
@@ -28,12 +28,12 @@ func TestCreateOauth2Conf(t *testing.T) {
 			return "ERROR_THIS_SHOULD_NOT_BE_RETURNED_AT_ALL"
 		}
 	}
-	oauth2Conf := createOauth2Conf("/oauth-context", 8765, getEnvConfig)
+	oauth2Conf := initOauthClient("/oauth-context", 8765, getEnvConfig)
 
-	test.AssertString(t,"testClientId", oauth2Conf.ClientID, "Client ID is not correct in oauth conf")
-	test.AssertString(t,"http://localhost:8765/oauth-context", oauth2Conf.RedirectURL, "RedirectURL is not correct in oauth conf")
-	test.AssertString(t,"http://localhost/auth", oauth2Conf.Endpoint.AuthURL,
+	test.AssertString(t,"testClientId", oauth2Conf.oauthConf.ClientID, "Client ID is not correct in oauth conf")
+	test.AssertString(t,"http://localhost:8765/oauth-context", oauth2Conf.oauthConf.RedirectURL, "RedirectURL is not correct in oauth conf")
+	test.AssertString(t,"http://localhost/auth", oauth2Conf.oauthConf.Endpoint.AuthURL,
 		"AuthURL is not correct in oauth conf")
-	test.AssertString(t,"http://localhost/token", oauth2Conf.Endpoint.TokenURL,
+	test.AssertString(t,"http://localhost/token", oauth2Conf.oauthConf.Endpoint.TokenURL,
 		"TokenURL is not correct in oauth conf")
 }


### PR DESCRIPTION
## Describe your problem(s)

We cannot disable SSL cert verification with IDP for the client login functionality.

## Describe your solution

We can read the env config for client skip verify and use to skip SSL verification.

## Checklist

- [X] Unit tests
- ~Documentation~ usage of env config with CLI is already documented
- ~Updated release note~ not required since  we have used an existing config
