### PR TITLE
Display generate id in app list command

### DIFF
--- a/internal/pkg/client/application_client.go
+++ b/internal/pkg/client/application_client.go
@@ -30,7 +30,7 @@ func (c *cliClient) ListApps() ([]runtime.Application, error) {
 }
 
 func (c *cliClient) CreateNewApp(name string, desc string) error {
-	application := &runtime.Application{
+	application := &runtime.ApplicationRequest{
 		Name:        name,
 		Description: desc,
 	}

--- a/internal/pkg/client/application_client.go
+++ b/internal/pkg/client/application_client.go
@@ -42,22 +42,18 @@ func (c *cliClient) CreateNewApp(name string, desc string) error {
 	return nil
 }
 
-func (c *cliClient) DeployApp(repoUrl string) (string, error) {
+func (c *cliClient) DeployApp(repoUrl string) (runtime.DeploymentDetails, error) {
 	var deploymentRequest = struct {
 		RepoUrl string `json:"repo_url"`
 	}{
 		RepoUrl: repoUrl,
 	}
 
-	var deploymentDetails struct {
-		DeploymentUrl string `json:"deployment_url"`
-	}
-	err := c.httpClient.createRestResourceWithResponse(pathApplicationDeployment, &deploymentRequest, &deploymentDetails)
-	if err != nil {
-		return "", err
-	}
+	var deploymentDetails runtime.DeploymentDetails
 
-	return deploymentDetails.DeploymentUrl, nil
+	err := c.httpClient.createRestResourceWithResponse(pathApplicationDeployment, &deploymentRequest, &deploymentDetails)
+
+	return deploymentDetails, err
 }
 
 func (c *cliClient) FetchLogs(appId string, linesCount uint) (string, error) {

--- a/internal/pkg/client/application_client_test.go
+++ b/internal/pkg/client/application_client_test.go
@@ -113,10 +113,6 @@ func TestDeployAppError(t *testing.T) {
 }
 
 func TestDeployApp(t *testing.T) {
-	type deploymentDetails struct {
-		DeploymentUrl string `json:"deployment_url"`
-	}
-
 	var b bytes.Buffer
 	client := &cliClient{
 		out:   &b,
@@ -124,16 +120,18 @@ func TestDeployApp(t *testing.T) {
 		httpClient: &mockHttpClient{
 			createRestResourceWithResponseImpl: func(resourcePath string, requestData interface{},
 				responseData interface{}) error {
-				apps := responseData.(*struct {
-					DeploymentUrl string `json:"deployment_url"`
-				})
+				apps := responseData.(*runtime.DeploymentDetails)
 				apps.DeploymentUrl = "http://example.com/apps/url"
+				apps.ApplicationId = "appd83d56f4c6ff40428e8dd057c5b94bd5"
 				return nil
 			},
 		},
 	}
 
-	appUrl, _ := client.DeployApp("http://github.com/test/test")
+	deploymentDetails, _ := client.DeployApp("http://github.com/test/test")
 
-	test.AssertString(t, "http://example.com/apps/url", appUrl, "The app URL should be returned")
+	test.AssertString(t, "http://example.com/apps/url", deploymentDetails.DeploymentUrl,
+		"The app URL should be returned")
+	test.AssertString(t, "appd83d56f4c6ff40428e8dd057c5b94bd5", deploymentDetails.ApplicationId,
+		"The app id should be returned")
 }

--- a/internal/pkg/client/application_client_test.go
+++ b/internal/pkg/client/application_client_test.go
@@ -58,7 +58,7 @@ func TestListAppsError(t *testing.T) {
 }
 
 func TestCreateApp(t *testing.T) {
-	var actual *runtime.Application
+	var actual *runtime.ApplicationRequest
 
 	var b bytes.Buffer
 	client := &cliClient{
@@ -66,7 +66,7 @@ func TestCreateApp(t *testing.T) {
 		debug: &b,
 		httpClient: &mockHttpClient{
 			createRestResourceImpl: func(resourcePath string, data interface{}) error {
-				actual = data.(*runtime.Application)
+				actual = data.(*runtime.ApplicationRequest)
 				return nil
 			},
 		},
@@ -124,7 +124,9 @@ func TestDeployApp(t *testing.T) {
 		httpClient: &mockHttpClient{
 			createRestResourceWithResponseImpl: func(resourcePath string, requestData interface{},
 				responseData interface{}) error {
-				apps := responseData.(*struct { DeploymentUrl string `json:"deployment_url"`})
+				apps := responseData.(*struct {
+					DeploymentUrl string `json:"deployment_url"`
+				})
 				apps.DeploymentUrl = "http://example.com/apps/url"
 				return nil
 			},
@@ -135,4 +137,3 @@ func TestDeployApp(t *testing.T) {
 
 	test.AssertString(t, "http://example.com/apps/url", appUrl, "The app URL should be returned")
 }
-

--- a/internal/pkg/cmd/application/deploy.go
+++ b/internal/pkg/cmd/application/deploy.go
@@ -37,11 +37,13 @@ func runDeployAppCommand(cliContext runtime.CliContext) func(cmd *cobra.Command,
 			common.ExitWithErrorMessage(cliContext.Out(), "Please login first")
 		}
 
-		deploymentUrl, err := cliContext.Client().DeployApp(args[0])
+		deploymentDetails, err := cliContext.Client().DeployApp(args[0])
 		if err != nil {
 			common.ExitWithError(cliContext.Out(), "Error occurred while deploying the application", err)
 		} else {
-			common.PrintInfo(cliContext.Out(), "Deployment request submitted! Once deployed, the app can be accessed from: "+deploymentUrl)
+			common.PrintInfo(cliContext.Out(), "A new application is created for deployment with Id: "+
+				deploymentDetails.ApplicationId+"\nOnce deployed, the app can be accessed from: "+
+				deploymentDetails.DeploymentUrl)
 		}
 	}
 }

--- a/internal/pkg/cmd/application/deploy_test.go
+++ b/internal/pkg/cmd/application/deploy_test.go
@@ -12,6 +12,7 @@ package application
 import (
 	"bytes"
 	cl "github.com/wso2/choreo-cli/internal/pkg/client"
+	dt "github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
 	"github.com/wso2/choreo-cli/internal/pkg/test/mock/client"
 	"github.com/wso2/choreo-cli/internal/pkg/test/mock/config"
 	"github.com/wso2/choreo-cli/internal/pkg/test/mock/runtime"
@@ -26,12 +27,14 @@ func TestNewDeployCommand(t *testing.T) {
 		MockOut:        &b,
 		MockUserConfig: config.NewMockConfigHolder(map[string]string{cl.AccessToken: "some-token"}),
 		MockEnvConfig:  config.NewMockConfigHolder(map[string]string{}),
-		MockClient: &client.MockClient{DeployApp_: func(repoUrl string) (s string, e error) {
-			return "https://development.choreo.dev/choreapps/123456/myapp", nil
+		MockClient: &client.MockClient{DeployApp_: func(repoUrl string) (d dt.DeploymentDetails, e error) {
+			return dt.DeploymentDetails{DeploymentUrl: "https://development.choreo.dev/choreoapps/appe1231bbf533d3f2e1287f437ff17d7c8", ApplicationId: "appe1231bbf533d3f2e1287f437ff17d7c8"}, nil
 		}},
 	})
 	deployCommand.Run(nil, []string{"https://github.com/someuser/myapp"})
 
-	expect := "Deployment request submitted! Once deployed, the app can be accessed from: https://development.choreo.dev/choreapps/123456/myapp" + "\n"
+	expect := "A new application is created for deployment with Id: appe1231bbf533d3f2e1287f437ff17d7c8" +
+		"\nOnce deployed, the app can be accessed from:" +
+		" https://development.choreo.dev/choreoapps/appe1231bbf533d3f2e1287f437ff17d7c8" + "\n"
 	test.AssertString(t, expect, b.String(), "Deployment command output is not as expected")
 }

--- a/internal/pkg/cmd/application/list_test.go
+++ b/internal/pkg/cmd/application/list_test.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 Inc. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package application
+
+import (
+	"bytes"
+	"github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
+	"github.com/wso2/choreo-cli/internal/pkg/test"
+	"testing"
+)
+
+func TestShowAppsCommandWithApps(t *testing.T) {
+	var b bytes.Buffer
+	var apps = []runtime.Application{{Id: "appee067864d5714595b9938812a8342b59", Name: "hello World",
+		Description: "My first hello world app"}, {Id: "app3a1f1edb0dce4db080f9135250600d7c", Name: "app1"}}
+	expect := `  ID                                    APPLICATION NAME   DESCRIPTION               
+ ------------------------------------- ------------------ -------------------------- 
+  appee067864d5714595b9938812a8342b59   hello World        My first hello world app  
+  app3a1f1edb0dce4db080f9135250600d7c   app1                                         
+`
+	showApps(&b, apps)
+	test.AssertString(t, expect, b.String(), "showApps command output is not as expected")
+}
+
+func TestShowAppsCommandWithoutApps(t *testing.T) {
+	var b bytes.Buffer
+	var apps []runtime.Application
+	expect := `No applications to show!
+`
+	showApps(&b, apps)
+	test.AssertString(t, expect, b.String(), "showApps command output is not as expected")
+}

--- a/internal/pkg/cmd/runtime/context.go
+++ b/internal/pkg/cmd/runtime/context.go
@@ -53,6 +53,12 @@ type ConsoleWriterHolder interface {
 }
 
 type Application struct {
+	Id          string `json:"id" header:"Id"`
+	Name        string `json:"name" header:"Application Name"`
+	Description string `json:"description" header:"Description"`
+}
+
+type ApplicationRequest struct {
 	Name        string `json:"name" header:"Application Name"`
 	Description string `json:"description" header:"Description"`
 }

--- a/internal/pkg/cmd/runtime/context.go
+++ b/internal/pkg/cmd/runtime/context.go
@@ -63,10 +63,15 @@ type ApplicationRequest struct {
 	Description string `json:"description" header:"Description"`
 }
 
+type DeploymentDetails struct {
+	DeploymentUrl string `json:"deployment_url"`
+	ApplicationId string `json:"app_id"`
+}
+
 type ApplicationApiClient interface {
 	CreateNewApp(name string, desc string) error
 	ListApps() ([]Application, error)
-	DeployApp(repoUrl string) (string, error)
+	DeployApp(repoUrl string) (DeploymentDetails, error)
 	FetchLogs(appId string, linesCount uint) (string, error)
 }
 

--- a/internal/pkg/test/mock/client/client.go
+++ b/internal/pkg/test/mock/client/client.go
@@ -14,7 +14,7 @@ import "github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
 type MockClient struct {
 	CreateNewApp_           func(name string, desc string) error
 	ListApps_               func() ([]runtime.Application, error)
-	DeployApp_              func(repoUrl string) (string, error)
+	DeployApp_              func(repoUrl string) (runtime.DeploymentDetails, error)
 	FetchLogs_              func(appId string, linesCount uint) (string, error)
 	CreateOauthStateString_ func() (string, error)
 }
@@ -33,11 +33,14 @@ func (c *MockClient) ListApps() ([]runtime.Application, error) {
 	return nil, nil
 }
 
-func (c *MockClient) DeployApp(repoUrl string) (string, error) {
+func (c *MockClient) DeployApp(repoUrl string) (runtime.DeploymentDetails, error) {
 	if c.DeployApp_ != nil {
 		return c.DeployApp_(repoUrl)
 	}
-	return "", nil
+	return runtime.DeploymentDetails{
+		DeploymentUrl: "",
+		ApplicationId: "",
+	}, nil
 }
 
 func (c *MockClient) FetchLogs(appId string, linesCount uint) (string, error) {


### PR DESCRIPTION
## Describe your problem(s)
Resolve https://github.com/wso2/choreo/issues/351

## Describe your solution
The `chor app list` command now displays the generated application id.

## Checklist

- [x] Unit tests
- [x] Documentation
- [x] Updated release note
